### PR TITLE
GitHub ActionsからFirebase Hostingへのデプロイを自動化

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,17 +13,16 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.41.2'
+          flutter-version-file: 'pubspec.yaml'
           channel: 'stable'
-          cache: true
 
       - name: Build Flutter web
-        run: flutter build web --release
+        run: make build
 
       - name: Deploy to Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_FLAPPY_STOCK_PROD }}
           projectId: flappy-stock-prod
           channelId: live


### PR DESCRIPTION
## Summary

- `FirebaseExtended/action-hosting-deploy@v0` を使ってFirebase Hostingへのデプロイを自動化
- サービスアカウントJSONをシークレット (`FIREBASE_SERVICE_ACCOUNT`) から読み込んで認証
- `main` ブランチへのpushをトリガーに `flutter build web --release` でビルド後にデプロイ

## 事前準備

リポジトリの Secrets に以下を設定してください：
- `FIREBASE_SERVICE_ACCOUNT`: Firebaseサービスアカウントの JSON

## Test plan

- [ ] `FIREBASE_SERVICE_ACCOUNT` シークレットをリポジトリに設定する
- [ ] `main` ブランチにpushしてワークフローが正常に実行されることを確認する
- [ ] Firebase Hostingにデプロイされていることを確認する

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)